### PR TITLE
upgraded image from jessie-slim to stretch-slim

### DIFF
--- a/sc/Dockerfile
+++ b/sc/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie-slim
+FROM debian:stretch-slim
 MAINTAINER The Goofball "goofball222@gmail.com"
 
 ARG BUILD_DATE
@@ -36,45 +36,35 @@ COPY root /
 
 RUN set -x \
     && groupadd -r mongodb -g $MONGO_GID \
-    && useradd --no-log-init -r -u $MONGO_UID -g $MONGO_GID mongodb \
+    && useradd --no-log-init -r -u $MONGO_UID -g $MONGO_GID mongodb -d /var/lib/mongodb -M -s /bin/false \
     && groupadd -r unifi -g $UNIFI_GID \
-    && useradd --no-log-init -r -u $UNIFI_UID -g $UNIFI_GID unifi \
+    && useradd --no-log-init -r -u $UNIFI_UID -g $UNIFI_GID unifi -d /var/lib/unifi -M -s /bin/false \
     && mkdir /usr/share/man/man1 \
-    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10 > /dev/null \
-    && echo "deb http://downloads-distro.mongodb.org/repo/debian-sysvinit dist 10gen" \
-        > /etc/apt/sources.list.d/mongodb.list \
-    && echo "deb http://ftp.debian.org/debian jessie-backports main" \
-        > /etc/apt/sources.list.d/jessie-backports.list \
-    && apt-get -qqy update > /dev/null \
+    && apt-get -qqy update \
+    && apt-get -qqy install apt-utils \
+    && apt-get -qqy upgrade \
     && apt-get -qqy --no-install-recommends install \
+        gnupg2 \
+        dirmngr \
         binutils \
-        curl > /dev/null \
-    && apt-get -qqy -t jessie-backports --no-install-recommends install \
+        procps \
+        libcap2 \
+        curl \
+        gosu \
+        jsvc \
         ca-certificates-java \
-        openjdk-8-jre-headless > /dev/null \
-    && apt-get -qqy --no-install-recommends install \
-        mongodb-org-server > /dev/null \
-    # Add gosu - easy step-down from uid 0 for running app
-    && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
-    && curl -sSL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch -o /usr/local/bin/gosu \
-    && curl -sSL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc -o /usr/local/bin/gosu.asc \
-    && export GNUPGHOME="$(mktemp -d)" \
-    # Verify the gosu signature
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
-    && chmod +x /usr/local/bin/gosu \
-    # Verify that the gosu binary works
-    && gosu nobody true \
+        openjdk-8-jre-headless \
+        mongodb \
+    && curl -sSL https://dl.ubnt.com/unifi/unifi-repo.gpg -o /etc/apt/trusted.gpg.d/unifi-repo.gpg \
     && curl -sSL https://dl.ubnt.com/unifi/$VERSION/unifi_sysvinit_all.deb -o /tmp/unifi.deb \
-    && apt-get -qqy purge curl > /dev/null \
-    && apt-get -qqy autoremove --purge > /dev/null \
-    && apt-get -qqy clean autoclean > /dev/null \
+    && apt-get -qqy purge curl \
+    && apt-get -qqy autoremove --purge \
+    && apt-get -qqy clean autoclean \
     && dpkg --force-all -i /tmp/unifi.deb \
     && rm /tmp/unifi.deb \
     && bash -c 'mkdir -p {data,logs,run,cert}' \
     && chown -R unifi:unifi /usr/lib/unifi \
-    && rm -rf /var/cache/apt/* /var/cache/debconf/* /var/lib/apt/* /var/lib/dpkg/* /tmp/* /var/tmp/* /var/log/*
+    && rm -rf /var/cache/apt/* /var/cache/debconf/* /tmp/* /var/tmp/* /var/log/*
 
 EXPOSE 3478/udp 6789/tcp 8080/tcp 8443/tcp 8843/tcp 8880/tcp 10001/udp
 

--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie-slim
+FROM debian:stretch-slim
 MAINTAINER The Goofball "goofball222@gmail.com"
 
 ARG BUILD_DATE
@@ -36,45 +36,35 @@ COPY root /
 
 RUN set -x \
     && groupadd -r mongodb -g $MONGO_GID \
-    && useradd --no-log-init -r -u $MONGO_UID -g $MONGO_GID mongodb \
+    && useradd --no-log-init -r -u $MONGO_UID -g $MONGO_GID mongodb -d /var/lib/mongodb -M -s /bin/false \
     && groupadd -r unifi -g $UNIFI_GID \
-    && useradd --no-log-init -r -u $UNIFI_UID -g $UNIFI_GID unifi \
+    && useradd --no-log-init -r -u $UNIFI_UID -g $UNIFI_GID unifi -d /var/lib/unifi -M -s /bin/false \
     && mkdir /usr/share/man/man1 \
-    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10 > /dev/null \
-    && echo "deb http://downloads-distro.mongodb.org/repo/debian-sysvinit dist 10gen" \
-        > /etc/apt/sources.list.d/mongodb.list \
-    && echo "deb http://ftp.debian.org/debian jessie-backports main" \
-        > /etc/apt/sources.list.d/jessie-backports.list \
-    && apt-get -qqy update > /dev/null \
+    && apt-get -qqy update \
+    && apt-get -qqy install apt-utils \
+    && apt-get -qqy upgrade \
     && apt-get -qqy --no-install-recommends install \
+        gnupg2 \
+        dirmngr \
         binutils \
-        curl > /dev/null \
-    && apt-get -qqy -t jessie-backports --no-install-recommends install \
+        procps \
+        libcap2 \
+        curl \
+        gosu \
+        jsvc \
         ca-certificates-java \
-        openjdk-8-jre-headless > /dev/null \
-    && apt-get -qqy --no-install-recommends install \
-        mongodb-org-server > /dev/null \
-    # Add gosu - easy step-down from uid 0 for running app
-    && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
-    && curl -sSL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch -o /usr/local/bin/gosu \
-    && curl -sSL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc -o /usr/local/bin/gosu.asc \
-    && export GNUPGHOME="$(mktemp -d)" \
-    # Verify the gosu signature
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
-    && chmod +x /usr/local/bin/gosu \
-    # Verify that the gosu binary works
-    && gosu nobody true \
+        openjdk-8-jre-headless \
+        mongodb \
+    && curl -sSL https://dl.ubnt.com/unifi/unifi-repo.gpg -o /etc/apt/trusted.gpg.d/unifi-repo.gpg \
     && curl -sSL https://dl.ubnt.com/unifi/$VERSION/unifi_sysvinit_all.deb -o /tmp/unifi.deb \
-    && apt-get -qqy purge curl > /dev/null \
-    && apt-get -qqy autoremove --purge > /dev/null \
-    && apt-get -qqy clean autoclean > /dev/null \
+    && apt-get -qqy purge curl \
+    && apt-get -qqy autoremove --purge \
+    && apt-get -qqy clean autoclean \
     && dpkg --force-all -i /tmp/unifi.deb \
     && rm /tmp/unifi.deb \
     && bash -c 'mkdir -p {data,logs,run,cert}' \
     && chown -R unifi:unifi /usr/lib/unifi \
-    && rm -rf /var/cache/apt/* /var/cache/debconf/* /var/lib/apt/* /var/lib/dpkg/* /tmp/* /var/tmp/* /var/log/*
+    && rm -rf /var/cache/apt/* /var/cache/debconf/* /tmp/* /var/tmp/* /var/log/*
 
 EXPOSE 3478/udp 6789/tcp 8080/tcp 8443/tcp 8843/tcp 8880/tcp 10001/udp
 

--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie-slim
+FROM debian:stretch-slim
 MAINTAINER The Goofball "goofball222@gmail.com"
 
 ARG BUILD_DATE
@@ -36,45 +36,35 @@ COPY root /
 
 RUN set -x \
     && groupadd -r mongodb -g $MONGO_GID \
-    && useradd --no-log-init -r -u $MONGO_UID -g $MONGO_GID mongodb \
+    && useradd --no-log-init -r -u $MONGO_UID -g $MONGO_GID mongodb -d /var/lib/mongodb -M -s /bin/false \
     && groupadd -r unifi -g $UNIFI_GID \
-    && useradd --no-log-init -r -u $UNIFI_UID -g $UNIFI_GID unifi \
+    && useradd --no-log-init -r -u $UNIFI_UID -g $UNIFI_GID unifi -d /var/lib/unifi -M -s /bin/false \
     && mkdir /usr/share/man/man1 \
-    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10 > /dev/null \
-    && echo "deb http://downloads-distro.mongodb.org/repo/debian-sysvinit dist 10gen" \
-        > /etc/apt/sources.list.d/mongodb.list \
-    && echo "deb http://ftp.debian.org/debian jessie-backports main" \
-        > /etc/apt/sources.list.d/jessie-backports.list \
-    && apt-get -qqy update > /dev/null \
+    && apt-get -qqy update \
+    && apt-get -qqy install apt-utils \
+    && apt-get -qqy upgrade \
     && apt-get -qqy --no-install-recommends install \
+        gnupg2 \
+        dirmngr \
         binutils \
-        curl > /dev/null \
-    && apt-get -qqy -t jessie-backports --no-install-recommends install \
+        procps \
+        libcap2 \
+        curl \
+        gosu \
+        jsvc \
         ca-certificates-java \
-        openjdk-8-jre-headless > /dev/null \
-    && apt-get -qqy --no-install-recommends install \
-        mongodb-org-server > /dev/null \
-    # Add gosu - easy step-down from uid 0 for running app
-    && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
-    && curl -sSL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch -o /usr/local/bin/gosu \
-    && curl -sSL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc -o /usr/local/bin/gosu.asc \
-    && export GNUPGHOME="$(mktemp -d)" \
-    # Verify the gosu signature
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
-    && chmod +x /usr/local/bin/gosu \
-    # Verify that the gosu binary works
-    && gosu nobody true \
+        openjdk-8-jre-headless \
+        mongodb \
+    && curl -sSL https://dl.ubnt.com/unifi/unifi-repo.gpg -o /etc/apt/trusted.gpg.d/unifi-repo.gpg \
     && curl -sSL https://dl.ubnt.com/unifi/$VERSION/unifi_sysvinit_all.deb -o /tmp/unifi.deb \
-    && apt-get -qqy purge curl > /dev/null \
-    && apt-get -qqy autoremove --purge > /dev/null \
-    && apt-get -qqy clean autoclean > /dev/null \
+    && apt-get -qqy purge curl \
+    && apt-get -qqy autoremove --purge \
+    && apt-get -qqy clean autoclean \
     && dpkg --force-all -i /tmp/unifi.deb \
     && rm /tmp/unifi.deb \
     && bash -c 'mkdir -p {data,logs,run,cert}' \
     && chown -R unifi:unifi /usr/lib/unifi \
-    && rm -rf /var/cache/apt/* /var/cache/debconf/* /var/lib/apt/* /var/lib/dpkg/* /tmp/* /var/tmp/* /var/log/*
+    && rm -rf /var/cache/apt/* /var/cache/debconf/* /tmp/* /var/tmp/* /var/log/*
 
 EXPOSE 3478/udp 6789/tcp 8080/tcp 8443/tcp 8843/tcp 8880/tcp 10001/udp
 

--- a/unstable/Dockerfile
+++ b/unstable/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie-slim
+FROM debian:stretch-slim
 MAINTAINER The Goofball "goofball222@gmail.com"
 
 ARG BUILD_DATE
@@ -36,45 +36,35 @@ COPY root /
 
 RUN set -x \
     && groupadd -r mongodb -g $MONGO_GID \
-    && useradd --no-log-init -r -u $MONGO_UID -g $MONGO_GID mongodb \
+    && useradd --no-log-init -r -u $MONGO_UID -g $MONGO_GID mongodb -d /var/lib/mongodb -M -s /bin/false \
     && groupadd -r unifi -g $UNIFI_GID \
-    && useradd --no-log-init -r -u $UNIFI_UID -g $UNIFI_GID unifi \
+    && useradd --no-log-init -r -u $UNIFI_UID -g $UNIFI_GID unifi -d /var/lib/unifi -M -s /bin/false \
     && mkdir /usr/share/man/man1 \
-    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10 > /dev/null \
-    && echo "deb http://downloads-distro.mongodb.org/repo/debian-sysvinit dist 10gen" \
-        > /etc/apt/sources.list.d/mongodb.list \
-    && echo "deb http://ftp.debian.org/debian jessie-backports main" \
-        > /etc/apt/sources.list.d/jessie-backports.list \
-    && apt-get -qqy update > /dev/null \
+    && apt-get -qqy update \
+    && apt-get -qqy install apt-utils \
+    && apt-get -qqy upgrade \
     && apt-get -qqy --no-install-recommends install \
+        gnupg2 \
+        dirmngr \
         binutils \
-        curl > /dev/null \
-    && apt-get -qqy -t jessie-backports --no-install-recommends install \
+        procps \
+        libcap2 \
+        curl \
+        gosu \
+        jsvc \
         ca-certificates-java \
-        openjdk-8-jre-headless > /dev/null \
-    && apt-get -qqy --no-install-recommends install \
-        mongodb-org-server > /dev/null \
-    # Add gosu - easy step-down from uid 0 for running app
-    && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
-    && curl -sSL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch -o /usr/local/bin/gosu \
-    && curl -sSL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc -o /usr/local/bin/gosu.asc \
-    && export GNUPGHOME="$(mktemp -d)" \
-    # Verify the gosu signature
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
-    && chmod +x /usr/local/bin/gosu \
-    # Verify that the gosu binary works
-    && gosu nobody true \
+        openjdk-8-jre-headless \
+        mongodb \
+    && curl -sSL https://dl.ubnt.com/unifi/unifi-repo.gpg -o /etc/apt/trusted.gpg.d/unifi-repo.gpg \
     && curl -sSL https://dl.ubnt.com/unifi/$VERSION/unifi_sysvinit_all.deb -o /tmp/unifi.deb \
-    && apt-get -qqy purge curl > /dev/null \
-    && apt-get -qqy autoremove --purge > /dev/null \
-    && apt-get -qqy clean autoclean > /dev/null \
+    && apt-get -qqy purge curl \
+    && apt-get -qqy autoremove --purge \
+    && apt-get -qqy clean autoclean \
     && dpkg --force-all -i /tmp/unifi.deb \
     && rm /tmp/unifi.deb \
     && bash -c 'mkdir -p {data,logs,run,cert}' \
     && chown -R unifi:unifi /usr/lib/unifi \
-    && rm -rf /var/cache/apt/* /var/cache/debconf/* /var/lib/apt/* /var/lib/dpkg/* /tmp/* /var/tmp/* /var/log/*
+    && rm -rf /var/cache/apt/* /var/cache/debconf/* /tmp/* /var/tmp/* /var/log/*
 
 EXPOSE 3478/udp 6789/tcp 8080/tcp 8443/tcp 8843/tcp 8880/tcp 10001/udp
 


### PR DESCRIPTION
Changes proposed in this pull request:
- upgraded base image from jessie-slim to stretch-slim
- added /bin/false as shell for mongodb and unifi
- avoid external dependencies and use mongodb and gosu from the debian
repositories
- install apt-utils and run apt upgrade on each build (TBD?)
- added gnupg2, dirmngr, procps, libcap2, jsvc for compatibility with
debian stretch
- do no longer "kill" the dpkg/apt database (to allow inheritance for your images)

I've running this image my environment for a few days without any problems. Please review the changes and consider it for merging.