### PR TITLE
Update docker-compose.externaldb.yml

### DIFF
--- a/examples/docker-compose.externaldb.yml
+++ b/examples/docker-compose.externaldb.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   mongo:
-    image: mongo
+    image: mongo:3.6
     container_name: unifidb
     restart: unless-stopped
 #   By default docker-compose will create a new bridge network for the services in the compose file.


### PR DESCRIPTION
Added explicit version 3.6 for MongoDB for seemless migration from all-in-one image.

@goofball222
