### PR TITLE
Update openjdk paths in ld-musl-x86_64.path for OpenJDK 17

### DIFF
--- a/8.2/official/root/etc/ld-musl-x86_64.path
+++ b/8.2/official/root/etc/ld-musl-x86_64.path
@@ -1,6 +1,5 @@
 /lib
 /usr/lib
 /usr/local/lib
-/usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64
-/usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/jli
-/usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/server
+/usr/lib/jvm/java-17-openjdk/jre/lib
+/usr/lib/jvm/java-17-openjdk/jre/lib/server


### PR DESCRIPTION
* Update musl ld shared library search paths for OpenJDK 17 directories Fixes goofball222/unifi#142

Fixes #142 .

Changes proposed in this pull request:
- Update musl ld search paths for OpenJDK 17
  - Update versioned directory from `java-1.8-openjdk` to `java-17-openjdk`
  - Remove `amd64` path component; no longer exists
  - Remove `jli` path; directory no longer exists

@goofball222
